### PR TITLE
Added options runAutomatically,jobTime,retentionDays

### DIFF
--- a/plugins/modules/veeam_vbr_rest_jobs_manage.py
+++ b/plugins/modules/veeam_vbr_rest_jobs_manage.py
@@ -138,7 +138,10 @@ def run_module():
         type=dict(type='str', choices=("VirtualMachine", "vCenterServer"), default="VirtualMachine"),
         backupRepositoryId=dict(type='str', required=False),
         description=dict(type='str', required=False),
-        validate_certs=dict(type='bool', default='false')
+        validate_certs=dict(type='bool', default='false'),
+        runAutomatically=dict(type='bool', required=False, default='false'),
+        jobTime=dict(type=str, required=False),
+        retentionDays=dict(type=int, required=False)
     )
 
     required_if_args = [
@@ -208,6 +211,9 @@ def run_module():
         objectId = module.params['objectId']
         description = module.params['description']
         backupRepositoryId = module.params['backupRepositoryId']
+        runAutomatically = module.params['runAutomatically']
+        jobTime = module.params['jobTime']
+        retentionDays = module.params['retentionDays']
 
         body = {
             "name": jobName,
@@ -232,7 +238,7 @@ def run_module():
                 },
                 "retentionPolicy": {
                 "type": "Days",
-                "quantity": 7
+                "quantity": retentionDays if retentionDays is not None else 7  
                 }
             },
             "guestProcessing": {
@@ -255,11 +261,11 @@ def run_module():
                 }
             },
             "schedule": {
-                "runAutomatically": "false",
+                "runAutomatically": runAutomatically if runAutomatically is not None else False,
                 "daily": {
                     "dailyKind": "Everyday",
                     "isEnabled": "true",
-                    "localTime": "22:00",
+                    "localTime": jobTime,
                     "days": [
                         "sunday",
                         "monday",
@@ -410,6 +416,7 @@ def run_module():
                 }
             }
         }
+        
         bodyjson = json.dumps(body)
         headers = {
             'x-api-version': apiversion,


### PR DESCRIPTION
Added options runAutomatically,jobTime,retentionDays to manage those fields directly via the ansible module when creating/editing a job. 

Signed-off-by: Daniel Suman d.suman@outlook.it

## Description

I've added the following options to the module: runAutomatically,jobTime,retentionDays.

As of now, if you want to change those fields, you would still need to do an API call on top of the ansible module use.

With those changes, you can create and edit jobs directly via module which is convenient for readibility and ease of use.

I didn't make any comments on the code as from opinion is pretty straight up.

Fixes # (issue)

None

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

I have tested this changes with creating and editing jobs with the additionals options I've included.

### Checklist (check all applicable):

* [X ] My code follows the style guidelines of this project
* [X ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [X ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
