### PR TITLE
V13 support update & more

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,50 @@ veeamhub.veeam Release Notes
 
 This changelog describes changes after version 1.5.0.
 
+v2.3.4
+======
+
+Major Changes
+-------------
+
+- Added support for v13
+
+Minor Changes
+-------------
+
+- Updated ISO references to latest versions (https://github.com/VeeamHub/veeam-ansible/issues/75)
+- Added logic to enable/disable Cloud Connect maintenance mode before/after Veeam Backup & Replication upgrade
+- Added support to adjust time to wait for long running tasks to complete (https://github.com/VeeamHub/veeam-ansible/issues/73)
+
+Bugfixes
+-------------
+
+- Added logic to disable/enable backup jobs before/after Veeam Backup & Replication upgrade (https://github.com/VeeamHub/veeam-ansible/issues/74)
+- Added logic to ensure Veeam services are started before proceeding with upgrade (https://github.com/VeeamHub/veeam-ansible/issues/27)
+
+
+Breaking Changes
+-------------
+
+- Deprecated support for installing Veeam Backup & Replication version 11 and earlier.
+- Deprecated support for installing Veeam ONE. Depending on demand, Veeam ONE support may be reintroduced in a future release.
+
+v2.2.5
+======
+
+Minor Changes
+-------------
+
+- Added options to configuration additional Veeam Backup & Replication jobs settings (https://github.com/VeeamHub/veeam-ansible/pull/79)
+
+v2.2.4
+======
+
+Bugfixes
+--------
+
+- Fixed being unable to deploy VBR using LocalSystem account on a local PostgreSQL instance (https://github.com/VeeamHub/veeam-ansible/issues/80)
+
 v2.2.3
 ======
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -25,7 +25,7 @@ tags:
   - vem
   - em
 dependencies:
-  ansible.windows: '2.2.0'
-  community.windows: '2.1.0'
+  ansible.windows: '3.3.0'
+  community.windows: '3.1.0'
 repository: "https://github.com/VeeamHub/veeam-ansible"
 issues: "https://github.com/VeeamHub/veeam-ansible/issues"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: "veeamhub"
 name: "veeam"
-version: "2.2.5"
+version: "2.3.4"
 readme: "readme_galaxy.md"
 authors:
   - "Chris Arceneaux (https://www.arsano.ninja/)"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.16.0'

--- a/roles/veeam_vas/README.md
+++ b/roles/veeam_vas/README.md
@@ -1,12 +1,8 @@
 # veeamhub.veeam.veeam_vas
 
-An Ansible Role to administer the [Veeam Availability Suite](https://www.veeam.com/data-center-availability-suite.html). Here are products included in the Veeam Availability Suite:
+An Ansible Role to administer [Veeam Backup & Replication](https://www.veeam.com/products/veeam-data-platform/backup-recovery.html) [Veeam Backup Enterprise Manager](https://www.veeam.com/products/backup-enterprise-manager.html).
 
-- [Veeam Backup & Replication](https://www.veeam.com/vm-backup-recovery-replication-software.html)
-- [Veeam Backup Enterprise Manager](https://www.veeam.com/backup-enterprise-manager.html)
-- [Veeam ONE](https://www.veeam.com/virtualization-management-one-solution.html)
-
-Starting with version 12.1, the Veeam Backup & Replication Console can now be installed & upgraded!
+Starting with version 12.1, a standalone Veeam Backup & Replication Console can now be installed & upgraded!
 
 A big thanks to Markus Kraus ([@vMarkus_K](https://twitter.com/vMarkus_K))! I used his [code](https://github.com/mycloudrevolution/veeam_setup) as a starting point for this project.
 
@@ -22,46 +18,23 @@ A big thanks to Markus Kraus ([@vMarkus_K](https://twitter.com/vMarkus_K))! I us
     - [Veeam Backup \& Replication](#veeam-backup--replication)
     - [Veeam Backup Enterprise Manager](#veeam-backup-enterprise-manager)
     - [Veeam Backup \& Replication Console](#veeam-backup--replication-console)
-    - [Veeam ONE](#veeam-one)
   - [Example Playbooks](#example-playbooks)
-    - [Veeam Backup \& Replication Community Edition Install with ISO Download (v12.1+)](#veeam-backup--replication-community-edition-install-with-iso-download-v121)
-    - [Veeam Backup \& Replication Community Edition Install with ISO Download (v12)](#veeam-backup--replication-community-edition-install-with-iso-download-v12)
-    - [Veeam Backup \& Replication Community Edition Install with ISO Download (v11-)](#veeam-backup--replication-community-edition-install-with-iso-download-v11-)
-    - [Veeam Backup \& Replication Install with ISO Download (v12.1+)](#veeam-backup--replication-install-with-iso-download-v121)
-    - [Veeam Backup \& Replication Install with ISO Download (v12-)](#veeam-backup--replication-install-with-iso-download-v12-)
-    - [Veeam Backup \& Replication Install with ISO Download and remote Microsoft SQL (v12.1+)](#veeam-backup--replication-install-with-iso-download-and-remote-microsoft-sql-v121)
-    - [Veeam Backup \& Replication Install with ISO Download and remote PostgreSQL (v12.1+)](#veeam-backup--replication-install-with-iso-download-and-remote-postgresql-v121)
-    - [Veeam Backup \& Replication Install with ISO Download and remote Microsoft SQL (v12)](#veeam-backup--replication-install-with-iso-download-and-remote-microsoft-sql-v12)
-    - [Veeam Backup \& Replication Install with ISO Download and remote PostgreSQL (v12)](#veeam-backup--replication-install-with-iso-download-and-remote-postgresql-v12)
-    - [Veeam Backup \& Replication Install with ISO Download and remote SQL (v11-)](#veeam-backup--replication-install-with-iso-download-and-remote-sql-v11-)
-    - [Veeam Backup \& Replication Community Edition Install without ISO Download](#veeam-backup--replication-community-edition-install-without-iso-download)
-    - [Veeam Backup \& Replication Upgrade - Native Auth (v12.1+)](#veeam-backup--replication-upgrade---native-auth-v121)
-    - [Veeam Backup \& Replication Upgrade - Windows Auth (v12.1+)](#veeam-backup--replication-upgrade---windows-auth-v121)
-    - [Veeam Backup \& Replication Upgrade (v12-)](#veeam-backup--replication-upgrade-v12-)
+    - [Veeam Backup \& Replication Community Edition Install with ISO Download](#veeam-backup--replication-community-edition-install-with-iso-download)
+    - [Veeam Backup \& Replication Community Edition Install with ISO Download](#veeam-backup--replication-community-edition-install-with-iso-download-1)
+    - [Veeam Backup \& Replication Install with ISO Download](#veeam-backup--replication-install-with-iso-download)
+    - [Veeam Backup \& Replication Install with ISO Download and remote Microsoft SQL](#veeam-backup--replication-install-with-iso-download-and-remote-microsoft-sql)
+    - [Veeam Backup \& Replication Install with ISO Download and remote PostgreSQL](#veeam-backup--replication-install-with-iso-download-and-remote-postgresql)
+    - [Veeam Backup \& Replication Upgrade](#veeam-backup--replication-upgrade)
     - [Veeam Cloud Connect Server Upgrade](#veeam-cloud-connect-server-upgrade)
     - [Veeam Backup \& Replication Patch](#veeam-backup--replication-patch)
-    - [Veeam Backup Enterprise Manager Install without ISO Download (v12.1+)](#veeam-backup-enterprise-manager-install-without-iso-download-v121)
-    - [Veeam Backup Enterprise Manager Install without ISO Download (v12-)](#veeam-backup-enterprise-manager-install-without-iso-download-v12-)
-    - [Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL (v12.1+)](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-microsoft-sql-v121)
-    - [Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL (v12.1+)](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-postgresql-v121)
-    - [Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL (v12)](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-microsoft-sql-v12)
-    - [Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL (v12)](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-postgresql-v12)
-    - [Veeam Backup Enterprise Manager Install with ISO Download and remote SQL (v11-)](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-sql-v11-)
-    - [Veeam Backup Enterprise Manager Install including Cloud Connect Portal](#veeam-backup-enterprise-manager-install-including-cloud-connect-portal)
-    - [Veeam Backup Enterprise Manager Upgrade - Native Auth (v12.1+)](#veeam-backup-enterprise-manager-upgrade---native-auth-v121)
-    - [Veeam Backup Enterprise Manager Upgrade - Windows Auth (v12.1+)](#veeam-backup-enterprise-manager-upgrade---windows-auth-v121)
-    - [Veeam Backup Enterprise Manager Upgrade (v12-)](#veeam-backup-enterprise-manager-upgrade-v12-)
+    - [Veeam Backup Enterprise Manager Install without ISO Download](#veeam-backup-enterprise-manager-install-without-iso-download)
+    - [Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-microsoft-sql)
+    - [Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL](#veeam-backup-enterprise-manager-install-with-iso-download-and-remote-postgresql)
+    - [Veeam Backup Enterprise Manager Upgrade](#veeam-backup-enterprise-manager-upgrade)
     - [Veeam Backup Enterprise Manager Patch](#veeam-backup-enterprise-manager-patch)
     - [Veeam Backup \& Replication Console Install](#veeam-backup--replication-console-install)
     - [Veeam Backup \& Replication Console Install without ISO download](#veeam-backup--replication-console-install-without-iso-download)
     - [Veeam Backup \& Replication Console Upgrade](#veeam-backup--replication-console-upgrade)
-    - [Veeam ONE Install - Typical Deployment (single server)](#veeam-one-install---typical-deployment-single-server)
-    - [Veeam ONE Community Edition Install - Typical Deployment (single server)](#veeam-one-community-edition-install---typical-deployment-single-server)
-    - [Veeam ONE Install - Advanced Deployment (multi-server)](#veeam-one-install---advanced-deployment-multi-server)
-    - [Veeam ONE Install - Typical Deployment and remote SQL](#veeam-one-install---typical-deployment-and-remote-sql)
-    - [Veeam ONE Typical Upgrade](#veeam-one-typical-upgrade)
-    - [Veeam ONE Upgrade - Advanced Deployment (multi-server)](#veeam-one-upgrade---advanced-deployment-multi-server)
-    - [Veeam ONE Patch](#veeam-one-patch)
 
 ## How to use this Role
 
@@ -79,24 +52,22 @@ This collection depends on Windows modules (`ansible.windows` & `community.windo
 
 ### Ansible
 
-- Ansible 2.14+
+- Ansible 2.16+
 
 ### OS
 
+- Microsoft Windows Server 2025
 - Microsoft Windows Server 2022
 - Microsoft Windows Server 2019
 
 ### Veeam Software
 
 - Veeam Backup & Replication
-  - 11
   - 12
+  - 13
 - Veeam Backup Enterprise Manager
-  - 11
   - 12
-- Veeam ONE
-  - 11
-  - 12
+  - 13
 
 ## Role Variables
 
@@ -109,44 +80,29 @@ Variables are located in two different locations:
 
 ### General
 
-- If Veeam software other than the Veeam Availability Suite is installed on the same server, this software will be taken offline during the upgrade.
+- If Veeam software other than the Veeam Backup & Replication and Veeam Backup Enterprise Manager is installed on the same server, this software will be taken offline during the upgrade.
 
 ### Veeam Backup & Replication
 
-- Install/Patch/Upgrade only supports SQL authentication (no Windows auth)
-  - _Both Windows & Native SQL authentication are accepted for versions 12.1 and later._
+- Starting with v13, PowerShell 7 is used for Veeam cmdlets. Ansible is still catching up so modules in this collection do not support v13. For more information see [here](https://github.com/VeeamHub/veeam-ansible/issues/83).
 - Starting with v12, PostgreSQL is installed instead of SQL Express.
 - If a remote PostgreSQL database is chosen, performance tuning needs to be applied. The new `veeam_vbr_set_postgres_database_server_limits` module hosted in this collection can assist in this regard.
   - [Check out the sample playbook below](#Veeam-Backup--Replication-Install-with-ISO-Download-and-remote-PostgreSQL-v12)
-- After the upgrade, Veeam Agents (VAW, VAL) will need to be upgraded.
-- Optional plug-ins (see below) are not currently included in this collection
-  - _These plugins are now included for versions 12.1 and later._
-  - AWS Plug-in for Veeam Backup & Replication
-  - Microsoft Azure Plug-in for Veeam Backup & Replication
-  - Google Cloud Platform Plug-in for Veeam Backup & Replication
-  - Veeam Backup for Nutanix AHV
 
 ### Veeam Backup Enterprise Manager
 
-- Install/Patch/Upgrade only supports SQL authentication (no Windows auth)
-  - _Both Windows & Native SQL authentication are accepted for versions 12.1 and later._
 - Starting with v12, PostgreSQL is installed instead of SQL Express.
 - If a remote PostgreSQL database is chosen, performance tuning needs to be applied. The new `veeam_vbr_set_postgres_database_server_limits` module hosted in this collection can assist in this regard.
 
 ### Veeam Backup & Replication Console
 
-- Install/Upgrade only available for versions 12.1 and later
-
-### Veeam ONE
-
-- Install/Patch/Upgrade only supports Windows authentication (no SQL authentication)
-  - _This is a limitation of the Ansible Role and not the Veeam Product._
+- Install/Upgrade only available for versions 12.3 and later
 
 ## Example Playbooks
 
 Please note there are more configurations than the examples shown below. If you have any questions, please feel free to create an [issue](https://github.com/VeeamHub/veeam-ansible/issues/new/choose).
 
-### Veeam Backup & Replication Community Edition Install with ISO Download (v12.1+)
+### Veeam Backup & Replication Community Edition Install with ISO Download
 
 ```yaml
 - name: Veeam Backup & Replication Install
@@ -156,11 +112,11 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_install
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
 ```
 
-### Veeam Backup & Replication Community Edition Install with ISO Download (v12)
+### Veeam Backup & Replication Community Edition Install with ISO Download
 
 ```yaml
 - name: Veeam Backup & Replication Install
@@ -170,7 +126,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_install
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
         sql_install_username: "sql_install"
         sql_install_password: "ChangeM3!"
@@ -181,7 +137,7 @@ Please note there are more configurations than the examples shown below. If you 
         # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```
 
-### Veeam Backup & Replication Community Edition Install with ISO Download (v11-)
+### Veeam Backup & Replication Install with ISO Download
 
 ```yaml
 - name: Veeam Backup & Replication Install
@@ -191,57 +147,13 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_install
       vars:
-        version: "11"
-        iso_download: true
-        sql_install_username: "sql_install"
-        sql_install_password: "ChangeM3!"
-        sql_service_username: "svc_sql"
-        sql_service_password: "ChangeM3!"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup & Replication Install with ISO Download (v12.1+)
-
-```yaml
-- name: Veeam Backup & Replication Install
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true
         source_license: "/root/ansible/license.lic"
 ```
 
-### Veeam Backup & Replication Install with ISO Download (v12-)
-
-```yaml
-- name: Veeam Backup & Replication Install
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_install_username: "sql_install"
-        sql_install_password: "ChangeM3!"
-        sql_service_username: "svc_sql"
-        sql_service_password: "ChangeM3!"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup & Replication Install with ISO Download and remote Microsoft SQL (v12.1+)
+### Veeam Backup & Replication Install with ISO Download and remote Microsoft SQL
 
 ```yaml
 - name: Veeam Backup & Replication Install with Remote Microsoft SQL Server
@@ -251,7 +163,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_install
       vars:
-        version: "12"
+        version: "13"
         license: true
         source_license: "/root/ansible/license.lic"
         sql_express_setup: false
@@ -263,7 +175,7 @@ Please note there are more configurations than the examples shown below. If you 
         # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```
 
-### Veeam Backup & Replication Install with ISO Download and remote PostgreSQL (v12.1+)
+### Veeam Backup & Replication Install with ISO Download and remote PostgreSQL
 
 ```yaml
 - name: Veeam Backup & Replication Install with Remote PostgreSQL Server
@@ -273,7 +185,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_install
       vars:
-        version: "12"
+        version: "13"
         license: true
         source_license: "/root/ansible/license.lic"
         sql_express_setup: false
@@ -289,95 +201,7 @@ Please note there are more configurations than the examples shown below. If you 
          ram_gb: 30
 ```
 
-### Veeam Backup & Replication Install with ISO Download and remote Microsoft SQL (v12)
-
-```yaml
-- name: Veeam Backup & Replication Install with Remote Microsoft SQL Server
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "12"
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_engine: "0" # 0-MSSQL / 1-Postgres (default)
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup & Replication Install with ISO Download and remote PostgreSQL (v12)
-
-```yaml
-- name: Veeam Backup & Replication Install with Remote PostgreSQL Server
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "12"
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-    - name: Applying tuning on a remote PostgreSQL server running as the VBR DB
-       veeamhub.veeam.veeam_vbr_set_postgres_database_server_limits:
-         os_type: Windows
-         cpu_count: 16
-         ram_gb: 30
-```
-
-### Veeam Backup & Replication Install with ISO Download and remote SQL (v11-)
-
-```yaml
-- name: Veeam Backup & Replication Install with Remote SQL Server
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "11"
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup & Replication Community Edition Install without ISO Download
-
-```yaml
-- name: Veeam Backup & Replication Install
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_install
-      vars:
-        version: "12"
-        destination: "C:\\install\\"
-        destination_iso_file: "VeeamBackup&Replication_12.0.0.1420_20230209.iso"
-        sql_install_username: "sql_install"
-        sql_install_password: "ChangeM3!"
-        sql_service_username: "svc_sql"
-        sql_service_password: "ChangeM3!"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup & Replication Upgrade - Native Auth (v12.1+)
+### Veeam Backup & Replication Upgrade
 
 ```yaml
 - name: Veeam Backup & Replication Upgrade
@@ -387,41 +211,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_upgrade
       vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_authentication: "1" # 0-Windows (default) 1-Native
-        sql_password: "ChangeM3!"
-```
-
-### Veeam Backup & Replication Upgrade - Windows Auth (v12.1+)
-
-```yaml
-- name: Veeam Backup & Replication Upgrade
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-```
-
-### Veeam Backup & Replication Upgrade (v12-)
-
-```yaml
-- name: Veeam Backup & Replication Upgrade
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: vbr_upgrade
-      vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true
         source_license: "/root/ansible/license.lic"
@@ -437,7 +227,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_upgrade
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true
         source_license: "/root/ansible/license.lic"
@@ -455,10 +245,10 @@ Please note there are more configurations than the examples shown below. If you 
         tasks_from: vbr_patch
       vars:
         source: "C:\\install\\"
-        patch_file: "VeeamBackup&Replication_10.0.0.4461.update0.exe"
+        patch_file: "VeeamBackup&Replication_12.3.2.4165_20251014_patch.exe"
 ```
 
-### Veeam Backup Enterprise Manager Install without ISO Download (v12.1+)
+### Veeam Backup Enterprise Manager Install without ISO Download
 
 ```yaml
 - name: Veeam Backup Enterprise Manager Install
@@ -469,14 +259,14 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: em_install
       vars:
-        version: "12"
+        version: "13"
         destination: "C:\\install\\"
-        destination_iso_file: "VeeamBackup&Replication_12.0.0.1420_20230209.iso"
+        destination_iso_file: "VeeamBackup&Replication_13.0.1.180_20251114.iso"
         license: true #mandatory for EM
         source_license: "/root/ansible/license.lic"
 ```
 
-### Veeam Backup Enterprise Manager Install without ISO Download (v12-)
+### Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL
 
 ```yaml
 - name: Veeam Backup Enterprise Manager Install
@@ -487,32 +277,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: em_install
       vars:
-        version: "12"
-        destination: "C:\\install\\"
-        destination_iso_file: "VeeamBackup&Replication_12.0.0.1420_20230209.iso"
-        license: true #mandatory for EM
-        source_license: "/root/ansible/license.lic"
-        sql_install_username: "sql_install"
-        sql_install_password: "ChangeM3!"
-        sql_service_username: "svc_sql"
-        sql_service_password: "ChangeM3!"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL (v12.1+)
-
-```yaml
-- name: Veeam Backup Enterprise Manager Install
-  gather_facts: false
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_install
-      vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true #mandatory for EM
         source_license: "/root/ansible/license.lic"
@@ -525,7 +290,7 @@ Please note there are more configurations than the examples shown below. If you 
         # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```
 
-### Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL (v12.1+)
+### Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL
 
 ```yaml
 - name: Veeam Backup Enterprise Manager Install
@@ -536,7 +301,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: em_install
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true #mandatory for EM
         source_license: "/root/ansible/license.lic"
@@ -548,99 +313,7 @@ Please note there are more configurations than the examples shown below. If you 
         # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```
 
-### Veeam Backup Enterprise Manager Install with ISO Download and remote Microsoft SQL (v12)
-
-```yaml
-- name: Veeam Backup Enterprise Manager Install
-  gather_facts: false
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_install
-      vars:
-        version: "12"
-        iso_download: true
-        license: true #mandatory for EM
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_engine: "0" # 0-MSSQL / 1-Postgres (default)
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup Enterprise Manager Install with ISO Download and remote PostgreSQL (v12)
-
-```yaml
-- name: Veeam Backup Enterprise Manager Install
-  gather_facts: false
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_install
-      vars:
-        version: "12"
-        iso_download: true
-        license: true #mandatory for EM
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup Enterprise Manager Install with ISO Download and remote SQL (v11-)
-
-```yaml
-- name: Veeam Backup Enterprise Manager Install
-  gather_facts: false
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_install
-      vars:
-        version: "11"
-        iso_download: true
-        license: true #mandatory for EM
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_instance: "sql.contoso.local"
-        sql_username: "svc_veeam"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup Enterprise Manager Install including Cloud Connect Portal
-
-```yaml
-- name: Veeam Backup Enterprise Manager Install including Cloud Connect Portal
-  gather_facts: false
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_install
-      vars:
-        version: "12"
-        iso_download: true
-        license: true #mandatory for EM
-        source_license: "/root/ansible/license.lic"
-        cloud_connect: true
-        sql_install_username: "sql_install"
-        sql_install_password: "ChangeM3!"
-        sql_service_username: "svc_sql"
-        sql_service_password: "ChangeM3!"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-```
-
-### Veeam Backup Enterprise Manager Upgrade - Native Auth (v12.1+)
+### Veeam Backup Enterprise Manager Upgrade
 
 ```yaml
 - name: Backup Enterprise Manager Upgrade
@@ -650,49 +323,10 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: em_upgrade
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
         license: true
         source_license: "/root/ansible/license.lic"
-        sql_authentication: "1" # 0-Windows (default) 1-Native
-        sql_password: "ChangeM3!"
-```
-
-### Veeam Backup Enterprise Manager Upgrade - Windows Auth (v12.1+)
-
-```yaml
-- name: Backup Enterprise Manager Upgrade
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-```
-
-### Veeam Backup Enterprise Manager Upgrade (v12-)
-
-```yaml
-- name: Backup Enterprise Manager Upgrade
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: em_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_instance: "sql.contoso.local"
-        sql_database: "VeeamBackupReporting"
-        sql_username: "sa"
-        sql_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```
 
 ### Veeam Backup Enterprise Manager Patch
@@ -706,7 +340,7 @@ Please note there are more configurations than the examples shown below. If you 
         tasks_from: em_patch
       vars:
         source: "C:\\install\\"
-        patch_file: "VeeamBackup&Replication_10.0.0.4461.update0.exe"
+        patch_file: "VeeamBackup&Replication_12.3.2.4165_20251014_patch.exe"
         sql_instance: "sql.contoso.local"
         sql_database: "VeeamBackupReporting"
         sql_username: "sa"
@@ -724,7 +358,7 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_console_install
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
 ```
 
@@ -738,9 +372,9 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_console_install
       vars:
-        version: "12"
+        version: "13"
         destination: "C:\\install\\"
-        destination_iso_file: "VeeamBackup&Replication_12.1.1.56_20240127.iso"
+        destination_iso_file: "VeeamBackup&Replication_13.0.1.180_20251114.iso"
 ```
 
 ### Veeam Backup & Replication Console Upgrade
@@ -753,271 +387,6 @@ Please note there are more configurations than the examples shown below. If you 
         name: veeamhub.veeam.veeam_vas
         tasks_from: vbr_console_upgrade
       vars:
-        version: "12"
+        version: "13"
         iso_download: true
-```
-
-### Veeam ONE Install - Typical Deployment (single server)
-
-```yaml
-- name: Installing Veeam ONE Install (Typical Deployment)
-  gather_facts: false
-  hosts: veeam
-
-  vars:
-    version: "12"
-    iso_download: false #this way ISO is only downloaded once
-    license: true
-    source_license: "/root/ansible/license.lic"
-    sql_express_setup: true
-    sql_service_username: "svc_sql"
-    sql_service_password: "ChangeM3!"
-    one_create_service_account: true #true==local false==domain
-    one_username: "svc_one"
-    one_password: "ChangeM3!"
-    # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-  tasks:
-    - name: Veeam ONE Server installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_install
-      vars:
-        iso_download: true #this way ISO is only downloaded once
-    - name: Veeam ONE Web UI installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_install
-    - name: Veeam ONE Monitoring Client installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_install
-```
-
-### Veeam ONE Community Edition Install - Typical Deployment (single server)
-
-```yaml
-- name: Installing Veeam ONE Install (Typical Deployment)
-  gather_facts: false
-  hosts: veeam
-
-  vars:
-    version: "12"
-    iso_download: false #this way ISO is only downloaded once
-    sql_express_setup: true
-    sql_service_username: "svc_sql"
-    sql_service_password: "ChangeM3!"
-    one_create_service_account: true #true==local false==domain
-    one_username: "svc_one"
-    one_password: "ChangeM3!"
-    # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-  tasks:
-    - name: Veeam ONE Server installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_install
-      vars:
-        iso_download: true #this way ISO is only downloaded once
-    - name: Veeam ONE Web UI installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_install
-    - name: Veeam ONE Monitoring Client installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_install
-```
-
-### Veeam ONE Install - Advanced Deployment (multi-server)
-
-```yaml
-- name: Veeam ONE Advanced Deployment - Veeam ONE Server
-  gather_facts: false
-  hosts: server
-  tasks:
-    - name: Veeam ONE Server installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_install
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_express_setup: false
-        sql_instance: "sql.contoso.local"
-        sql_database: "VeeamOne"
-        one_installation_type: "1" #1-Advanced | 2-Backup data only | 3-Typical
-        one_create_service_account: false #true==local false==domain
-        one_username: "contoso\\jsmith"
-        one_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-
-- name: Veeam ONE Advanced Deployment - Veeam Web UI
-  gather_facts: false
-  hosts: web
-  tasks:
-    - name: Veeam ONE Web UI installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_install
-      vars:
-        version: "12"
-        iso_download: true
-        one_create_service_account: false #true==local false==domain
-        one_username: "contoso\\jsmith"
-        one_password: "ChangeM3!"
-        one_server: "server.contoso.local"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-
-- name: Veeam ONE Advanced Deployment - Monitoring Client
-  gather_facts: false
-  hosts: client
-  tasks:
-    - name: Veeam ONE Monitoring Client installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_install
-      vars:
-        version: "12"
-        iso_download: true
-        one_server: "server.contoso.local"
-```
-
-### Veeam ONE Install - Typical Deployment and remote SQL
-
-```yaml
-- name: Installing Veeam ONE Install (Typical Deployment)
-  gather_facts: false
-  hosts: veeam
-
-  vars:
-    version: "12"
-    iso_download: false #this way ISO is only downloaded once
-    license: true
-    source_license: "/root/ansible/license.lic"
-    sql_express_setup: false
-    sql_instance: "sql.contoso.local"
-    sql_database: "VeeamOne"
-    one_create_service_account: false #true==local false==domain
-    one_username: "contoso\\jsmith"
-    one_password: "ChangeM3!"
-    # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-  tasks:
-    - name: Veeam ONE Server installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_install
-      vars:
-        iso_download: true #this way ISO is only downloaded once
-    - name: Veeam ONE Web UI installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_install
-    - name: Veeam ONE Monitoring Client installation tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_install
-```
-
-### Veeam ONE Typical Upgrade
-
-```yaml
-- name: Veeam ONE Upgrade
-  gather_facts: false
-  hosts: veeam
-
-  vars:
-    version: "12"
-    iso_download: false  #this way ISO is only downloaded once
-    license: true
-    source_license: "/root/ansible/license.lic"
-    one_username: "svc_one"
-    one_password: "ChangeM3!"
-    # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-  tasks:
-    - name: Veeam ONE Server upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_upgrade
-      vars:
-        iso_download: true  #this way ISO is only downloaded once
-    - name: Veeam ONE Web UI upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_upgrade
-    - name: Veeam ONE Monitoring Client upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_upgrade
-    - name: Rebooting server now to complete upgrade
-      ansible.windows.win_reboot:
-        msg: Reboot initiated by Ansible to complete Veeam ONE upgrade
-```
-
-### Veeam ONE Upgrade - Advanced Deployment (multi-server)
-
-```yaml
-- name: Veeam ONE Advanced Deployment - Veeam ONE Server
-  gather_facts: false
-  hosts: server
-  tasks:
-    - name: Veeam ONE Server upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_server_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        license: true
-        source_license: "/root/ansible/license.lic"
-        sql_instance: "sql.contoso.local"
-        sql_database: "VeeamOne"
-        one_username: "contoso\\jsmith"
-        one_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-
-- name: Veeam ONE Advanced Deployment - Veeam Web UI
-  hosts: web
-  gather_facts: false
-  tasks:
-    - name: Veeam ONE Web UI upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_web_ui_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        one_username: "contoso\\jsmith"
-        one_password: "ChangeM3!"
-        one_server: "server.contoso.local"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
-
-- name: Veeam ONE Advanced Deployment - Monitoring Client
-  hosts: client
-  gather_facts: false
-  tasks:
-    - name: Veeam ONE Monitoring Client upgrade tasks
-      include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_client_upgrade
-      vars:
-        version: "12"
-        iso_download: true
-        one_server: "server.contoso.local"
-```
-
-### Veeam ONE Patch
-
-```yaml
-- name: Veeam ONE Patch
-  hosts: veeam
-  tasks:
-    - include_role:
-        name: veeamhub.veeam.veeam_vas
-        tasks_from: one_patch
-      vars:
-        source: "C:\\install\\"
-        patch_file: "VeeamONE_9.5.4.4587_Update#4a.exe"
-        one_password: "ChangeM3!"
-        # https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-variables
 ```

--- a/roles/veeam_vas/defaults/main.yml
+++ b/roles/veeam_vas/defaults/main.yml
@@ -4,6 +4,10 @@
 # Major version of Veeam software being installed
 version: "12" # "10", & "11" are also accepted
 
+# Retries allowed for long-running Veeam operations (ISO download, install, upgrade)
+# Each retry is 60 seconds apart, so 60 retries = max 1 hour wait time
+veeam_retries: 60
+
 # ISO & License files
 skip_iso_check: false
 iso_download: false

--- a/roles/veeam_vas/defaults/main.yml
+++ b/roles/veeam_vas/defaults/main.yml
@@ -14,6 +14,7 @@ iso_download: false
 iso_checksum_algorithm: "sha1"
 license: false
 license_autoupdate: 1 # NFR and Evaluation licenses must be set to 1 - Licenses without license ID information must be set to 0
+proactive_support: 1 # NFR and Evaluation licenses must be set to 1 - Enable Proactive Support (v13 and above)
 source_license: ""
 destination: "C:\\install\\"
 

--- a/roles/veeam_vas/defaults/main.yml
+++ b/roles/veeam_vas/defaults/main.yml
@@ -32,8 +32,11 @@ em_tls: "1" # 1-Enabled 0-Disabled Use TLS 1.2 protocol for secure communication
 
 # VBR Plug-in installation (only for v12.1 and newer)
 # 1-Install 0-Do not install
+vbr_entra_id_install: "1" # Veeam Backup for Microsoft Entra ID
 vbr_ahv_install: "1" # Veeam Backup for Nutanix AHV
-vbr_rhv_install: "1" # Veeam Backup for Red Hat Virtualization
+vbr_rhv_install: "1" # Veeam Backup for Red Hat Virtualization (now Oracle KVM)
+vbr_kvm_install: "1" # Veeam Backup for Oracle KVM
+vbr_pve_install: "1" # Veeam Backup for Proxmox
 vbr_aws_install: "1" # Veeam Backup for AWS
 vbr_azure_install: "1" # Veeam Backup for Azure
 vbr_gcp_install: "1" # Veeam Backup for GCP

--- a/roles/veeam_vas/meta/main.yml
+++ b/roles/veeam_vas/meta/main.yml
@@ -1,28 +1,30 @@
 ---
 galaxy_info:
   author: Chris Arceneaux
-  description: Administer Veeam Availability Suite (VBR/EM/ONE)
+  description: Administer Veeam Software
   company: VeeamHub
   license: GPL-3.0-only
-  min_ansible_version: '2.14.0'
+  min_ansible_version: '2.16.0'
   platforms:
     - name: Windows
       versions:
+        - '2025'
         - '2022'
         - '2019'
   galaxy_tags:
     - veeam
     - availability
     - suite
+    - platform
     - backup
     - replication
     - enterprise
     - manager
-    - one
     - server
     - system
     - backup
     - vbr
     - vem
     - em
+    - vbem
 dependencies: []

--- a/roles/veeam_vas/tasks/em_install.yml
+++ b/roles/veeam_vas/tasks/em_install.yml
@@ -8,11 +8,15 @@
     msg: "Windows server requires a reboot. After reboot, you can proceed with the Veeam Backup Enterprise Manager install."
   when:
     - precheck.pending_reboot | bool
+- name: Checking to see if PostgreSQL is installed
+  veeam_software_check:
+    name: "postgres*"
+  register: postgres
 - name: Are unsupported SQL server settings specified in playbook?
   ansible.builtin.fail:
     msg: "Windows authentication is not supported for remote SQL server with LOCAL SYSTEM service account. Specify a different service account, or use native SQL authentication."
   when:
-    - not sql_express_setup
+    - not sql_express_setup and not (postgres.installed | bool)
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
 - name: Checking to see if Veeam Backup & Replication Server is installed
@@ -44,11 +48,13 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Legacy install process will be used
   ansible.builtin.set_fact:
     legacy: true
-  when: not file.matched | bool or file_version.win_file_version.file_version == '1.0.0.0'
+  when:
+    - file.matched == 0
+    - file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Installation Configuration
 - name: Print Installation Configuration

--- a/roles/veeam_vas/tasks/em_install.yml
+++ b/roles/veeam_vas/tasks/em_install.yml
@@ -12,6 +12,7 @@
   ansible.builtin.fail:
     msg: "Windows authentication is not supported for remote SQL server with LOCAL SYSTEM service account. Specify a different service account, or use native SQL authentication."
   when:
+    - not sql_express_setup
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
 - name: Checking to see if Veeam Backup & Replication Server is installed

--- a/roles/veeam_vas/tasks/em_patch.yml
+++ b/roles/veeam_vas/tasks/em_patch.yml
@@ -29,7 +29,9 @@
 - name: Stopping all Veeam services prior to applying EM patch
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 - name: Ensure the required NuGet package provider version is installed
   ansible.windows.win_shell: |
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
@@ -71,7 +73,8 @@
   retries: 3
 - name: Stopping all Veeam services
   ansible.windows.win_shell: |
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
   when: not (patch | bool)
 - name: Rebooting server now to complete EM patch installation
   ansible.windows.win_reboot:

--- a/roles/veeam_vas/tasks/em_upgrade.yml
+++ b/roles/veeam_vas/tasks/em_upgrade.yml
@@ -45,11 +45,13 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Legacy install process will be used
   ansible.builtin.set_fact:
     legacy: true
-  when: not file.matched | bool or file_version.win_file_version.file_version == '1.0.0.0'
+  when:
+    - file.matched == 0
+    - file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Upgrade Configuration
 - name: Print Upgrade Configuration

--- a/roles/veeam_vas/tasks/legacy_em_upgrade.yml
+++ b/roles/veeam_vas/tasks/legacy_em_upgrade.yml
@@ -19,7 +19,9 @@
 - name: Stopping all Veeam services prior to upgrade
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 - name: Ensure the required NuGet package provider version is installed
   ansible.windows.win_shell: |
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/roles/veeam_vas/tasks/legacy_vbr_upgrade.yml
+++ b/roles/veeam_vas/tasks/legacy_vbr_upgrade.yml
@@ -31,7 +31,9 @@
 - name: Stopping all Veeam services prior to upgrade
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 - name: .NET Framework
   ansible.builtin.include_tasks: install_net_framework.yml
 - name: Looking for .NET Core Runtime in Veeam ISO
@@ -280,7 +282,9 @@
   ansible.windows.win_shell: |
     if (-Not (Get-Module -ListAvailable -Name Veeam.Backup.PowerShell)){Add-PSSnapin -PassThru VeeamPSSnapIn -ErrorAction Stop | Out-Null}
     Get-VBRJob | Stop-VBRJob | Out-Null
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 - name: Unmount ISO
   community.windows.win_disk_image:
     image_path: "{{ destination }}{{ destination_iso_file }}"

--- a/roles/veeam_vas/tasks/mount_iso.yml
+++ b/roles/veeam_vas/tasks/mount_iso.yml
@@ -16,7 +16,7 @@
     force: true
   register: win_get_url_out
   retries: 3
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   when: iso_download | bool
 - name: Check on download status
@@ -24,8 +24,8 @@
     jid: "{{ win_get_url_out.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 120
-  delay: 30
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
   when: iso_download | bool
 - name: Debug Download Result
   ansible.builtin.debug:

--- a/roles/veeam_vas/tasks/new_em_install.yml
+++ b/roles/veeam_vas/tasks/new_em_install.yml
@@ -28,7 +28,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}EmAnswerFile_install.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on Enterprise Manager install status
@@ -36,8 +36,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-INSTALL TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/new_em_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_em_upgrade.yml
@@ -12,6 +12,15 @@
     src: templates/EM/EmAnswerFile_upgrade.xml.j2
     dest: "{{ destination }}EmAnswerFile_upgrade.xml"
     mode: '777'
+- name: Stopping all Veeam Backup Jobs (Only if VBR installed on same server as EM)
+  ansible.windows.win_shell: |
+    if (-Not (Get-Module -ListAvailable -Name Veeam.Backup.PowerShell)){Add-PSSnapin -PassThru VeeamPSSnapIn -ErrorAction Stop | Out-Null}
+    Get-VBRJob | Stop-VBRJob | Out-Null
+  when: software.installed | bool
+- name: Stopping all Veeam services prior to upgrade
+  ansible.windows.win_shell: |
+    Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
+    Get-Service veeam* | Stop-Service
 
 # UPGRADING VEEAM SOFTWARE
 - name: Upgrade Veeam Backup Enterprise Manager

--- a/roles/veeam_vas/tasks/new_em_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_em_upgrade.yml
@@ -20,7 +20,9 @@
 - name: Stopping all Veeam services prior to upgrade
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 
 # UPGRADING VEEAM SOFTWARE
 - name: Upgrade Veeam Backup Enterprise Manager

--- a/roles/veeam_vas/tasks/new_em_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_em_upgrade.yml
@@ -19,7 +19,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}EmAnswerFile_upgrade.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on Enterprise Manager upgrade status
@@ -27,8 +27,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-UPGRADE TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/new_vbr_install.yml
+++ b/roles/veeam_vas/tasks/new_vbr_install.yml
@@ -28,7 +28,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}VbrAnswerFile_install.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on Veeam Backup & Replication install status
@@ -36,8 +36,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-INSTALL TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/new_vbr_install.yml
+++ b/roles/veeam_vas/tasks/new_vbr_install.yml
@@ -16,6 +16,10 @@
     groups:
       - Administrators
   when: create_service_account | bool
+- name: If PostgreSQL is installed, there's no reason to install for Entra
+  ansible.builtin.set_fact:
+    vbr_entra_id_install: "0"
+  when: postgres.installed | bool
 - name: Create VBR silent install answer file
   ansible.builtin.template:
     src: templates/VBR/VbrAnswerFile_install.xml.j2

--- a/roles/veeam_vas/tasks/new_vbr_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_vbr_upgrade.yml
@@ -19,7 +19,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}VbrAnswerFile_upgrade.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on Veeam Backup & Replication upgrade status
@@ -27,8 +27,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-UPGRADE TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/new_vbr_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_vbr_upgrade.yml
@@ -7,6 +7,14 @@
     src: "{{ source_license }}"
     dest: "{{ destination }}{{ destination_license_file }}"
   when: license | bool
+- name: Checking to see if PostgreSQL is installed
+  veeam_software_check:
+    name: "postgres*"
+  register: postgres
+- name: If PostgreSQL is installed, there's no reason to install for Entra
+  ansible.builtin.set_fact:
+    vbr_entra_id_install: "0"
+  when: postgres.installed | bool
 - name: Create VBR silent upgrade answer file
   ansible.builtin.template:
     src: templates/VBR/VbrAnswerFile_upgrade.xml.j2
@@ -32,7 +40,9 @@
 - name: Stopping all Veeam services prior to upgrade
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 
 # UPGRADING VEEAM SOFTWARE
 - name: Upgrade Veeam Backup & Replication
@@ -52,19 +62,6 @@
   delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-UPGRADE TASKS
-- name: Ensure Veeam services are running before proceeding
-  ansible.windows.win_shell: |
-    Get-Service veeam* | Where-Object {$_.Name -ne "VeeamMBPDeploymentService"} | Start-Service
-  retries: 3
-- name: Disable Cloud Connect Maintenance Mode
-  veeam_vbr_cloud_connect_maintenance:
-    state: disable
-  when: cloud_connect | bool
-- name: Enabling all backup jobs in specified file
-  veeam_vbr_upgrade_job_prep:
-    state: enable
-    jobs_file: "{{ vbr_jobs_file }}"
-  when: not (cloud_connect | bool)
 - name: Unmount ISO
   community.windows.win_disk_image:
     image_path: "{{ destination }}{{ destination_iso_file }}"
@@ -76,3 +73,79 @@
   ansible.windows.win_reboot:
     msg: Reboot initiated by Ansible to complete VBR upgrade
   when: postcheck.pending_reboot | bool
+- name: Ensure Veeam is running (v12 and below)
+  ansible.windows.win_service_info:
+    name: VeeamBackupSvc
+  register: service_status
+  until:
+    - service_status.exists
+    - service_status.services[0].state == "started"
+  retries: 60
+  delay: 10 # 10 seconds * 60 retries = ~10 minutes max wait
+  when: version | int <= 12
+- name: Ensure Veeam is running (v13 and above)
+  ansible.windows.win_service_info:
+    name: VeeamWebSvc
+  register: service_status
+  until:
+    - service_status.exists
+    - service_status.services[0].state == "started"
+  retries: 60
+  delay: 10 # 10 seconds * 60 retries = ~10 minutes max wait
+  when: version | int >= 13
+- name: Disable Cloud Connect Maintenance Mode (v12 and below)
+  veeam_vbr_cloud_connect_maintenance:
+    state: disable
+  when:
+    - cloud_connect | bool
+    - version | int <= 12
+- name: Enabling all backup jobs in specified file (v12 and below)
+  veeam_vbr_upgrade_job_prep:
+    state: enable
+    jobs_file: "{{ vbr_jobs_file }}"
+  when:
+    - not (cloud_connect | bool)
+    - version | int <= 12
+- name: Disable Cloud Connect Maintenance Mode (v13 and above)
+  ansible.windows.win_powershell:
+    script: |
+      $Ansible.Changed = $false
+      try {
+        Connect-VBRServer -Server localhost -ForceAcceptTlsCertificate
+        Disable-VBRCloudMaintenanceMode | Out-Null
+        $Ansible.Changed = $true
+      }
+      catch {
+        Write-Error "Failed to disable Cloud Connect Maintenance Mode: $_"
+      }
+    executable: pwsh.exe
+    arguments:
+      - -ExecutionPolicy
+      - ByPass
+  when:
+    - cloud_connect | bool
+    - version | int >= 13
+- name: Enabling all backup jobs in specified file (v13 and above)
+  ansible.windows.win_powershell:
+    script: |
+      $Ansible.Changed = $false
+      try {
+        $file = Import-Csv "{{ vbr_jobs_file }}"
+        if ($file.Count -ne 0) {
+            Connect-VBRServer -Server localhost -ForceAcceptTlsCertificate
+        }
+        foreach ($job in $file){
+            Enable-VBRJob -Job $job.Name | Out-Null
+            $Ansible.Changed = $true
+        }
+      }
+      catch {
+        Write-Error "Failed to enable backup jobs: $_"
+      }
+    executable: pwsh.exe
+    arguments:
+      - -ExecutionPolicy
+      - ByPass
+  when:
+    - not (cloud_connect | bool)
+    - version | int >= 13

--- a/roles/veeam_vas/tasks/new_vbr_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_vbr_upgrade.yml
@@ -12,6 +12,27 @@
     src: templates/VBR/VbrAnswerFile_upgrade.xml.j2
     dest: "{{ destination }}VbrAnswerFile_upgrade.xml"
     mode: '777'
+- name: Enable Cloud Connect Maintenance Mode
+  veeam_vbr_cloud_connect_maintenance:
+    state: enable
+  when: cloud_connect | bool
+- name: Start adhoc VBR configuration backup job
+  veeam_vbr_config_backup:
+    state: adhoc
+- name: Stopping and disabling all backup jobs
+  veeam_vbr_upgrade_job_prep:
+    state: disable
+    jobs_file: "{{ vbr_jobs_file }}"
+  when: not (cloud_connect | bool)
+  register: jobs
+- name: Print Backup Jobs backup file name
+  ansible.builtin.debug:
+    var: jobs
+  when: not (cloud_connect | bool)
+- name: Stopping all Veeam services prior to upgrade
+  ansible.windows.win_shell: |
+    Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
+    Get-Service veeam* | Stop-Service
 
 # UPGRADING VEEAM SOFTWARE
 - name: Upgrade Veeam Backup & Replication
@@ -31,6 +52,19 @@
   delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-UPGRADE TASKS
+- name: Ensure Veeam services are running before proceeding
+  ansible.windows.win_shell: |
+    Get-Service veeam* | Where-Object {$_.Name -ne "VeeamMBPDeploymentService"} | Start-Service
+  retries: 3
+- name: Disable Cloud Connect Maintenance Mode
+  veeam_vbr_cloud_connect_maintenance:
+    state: disable
+  when: cloud_connect | bool
+- name: Enabling all backup jobs in specified file
+  veeam_vbr_upgrade_job_prep:
+    state: enable
+    jobs_file: "{{ vbr_jobs_file }}"
+  when: not (cloud_connect | bool)
 - name: Unmount ISO
   community.windows.win_disk_image:
     image_path: "{{ destination }}{{ destination_iso_file }}"

--- a/roles/veeam_vas/tasks/vbr_console_install.yml
+++ b/roles/veeam_vas/tasks/vbr_console_install.yml
@@ -58,7 +58,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}VbrConsoleAnswerFile_install.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on install status
@@ -66,8 +66,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-INSTALL TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/vbr_console_install.yml
+++ b/roles/veeam_vas/tasks/vbr_console_install.yml
@@ -27,7 +27,7 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Using Unsupported Version
   ansible.builtin.fail:
     msg: "Veeam Backup & Replication Console installation is only supported for version 12.1 and later. If an incorrect ISO was used, please correct and try again."

--- a/roles/veeam_vas/tasks/vbr_console_upgrade.yml
+++ b/roles/veeam_vas/tasks/vbr_console_upgrade.yml
@@ -27,7 +27,7 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Using Unsupported Version
   ansible.builtin.fail:
     msg: "Veeam Backup & Replication Console upgrade is only supported for version 12.1 and later. If an incorrect ISO was used, please correct and try again."

--- a/roles/veeam_vas/tasks/vbr_console_upgrade.yml
+++ b/roles/veeam_vas/tasks/vbr_console_upgrade.yml
@@ -58,7 +58,7 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}VbrConsoleAnswerFile_upgrade.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: 3600
+  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on upgrade status
@@ -66,8 +66,8 @@
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
   until: async_poll_results.finished
-  retries: 60
-  delay: 60
+  retries: "{{ veeam_retries | int }}" # see main.yml for more info
+  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-UPGRADE TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -15,7 +15,6 @@
     - not sql_express_setup
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
-    - not sql_express_setup
 - name: Including version-specific variables
   ansible.builtin.include_vars:
     file: "vars/vbr_v{{ version }}.yml"

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -8,11 +8,15 @@
     msg: "This Windows server requires a reboot prior to beginning the Veeam Backup & Replication install. After rebooting this server, you can proceed with the installation."
   when:
     - precheck.pending_reboot | bool
+- name: Checking to see if PostgreSQL is installed
+  veeam_software_check:
+    name: "postgres*"
+  register: postgres
 - name: Are unsupported SQL server settings specified in playbook?
   ansible.builtin.fail:
     msg: "Windows authentication is not supported for remote SQL server with LOCAL SYSTEM service account. Specify a different service account, or use native SQL authentication."
   when:
-    - not sql_express_setup
+    - not sql_express_setup and not (postgres.installed | bool)
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
 - name: Including version-specific variables

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -34,11 +34,13 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Legacy install process will be used
   ansible.builtin.set_fact:
     legacy: true
-  when: not file.matched | bool or file_version.win_file_version.file_version == '1.0.0.0'
+  when:
+  - file.matched == 0
+  - file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Installation Configuration
 - name: Print Installation Configuration

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -12,7 +12,7 @@
   ansible.builtin.fail:
     msg: "Windows authentication is not supported for remote SQL server with LOCAL SYSTEM service account. Specify a different service account, or use native SQL authentication."
   when:
-    - sql_express_setup == false
+    - not sql_express_setup
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
 - name: Including version-specific variables
@@ -39,8 +39,8 @@
   ansible.builtin.set_fact:
     legacy: true
   when:
-  - file.matched == 0
-  - file_version.win_file_version.file_version == '1.0.0.0'
+    - file.matched == 0
+    - file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Installation Configuration
 - name: Print Installation Configuration

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -12,6 +12,7 @@
   ansible.builtin.fail:
     msg: "Windows authentication is not supported for remote SQL server with LOCAL SYSTEM service account. Specify a different service account, or use native SQL authentication."
   when:
+    - sql_express_setup == false
     - sql_authentication == "0"
     - service_account_username == "LocalSystem"
 - name: Including version-specific variables

--- a/roles/veeam_vas/tasks/vbr_patch.yml
+++ b/roles/veeam_vas/tasks/vbr_patch.yml
@@ -46,7 +46,9 @@
 - name: Stopping all Veeam services prior to applying VBR patch
   ansible.windows.win_shell: |
     Stop-Process -Name "Veeam.Backup.Shell" -Force -ErrorAction SilentlyContinue
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
 
 ## INSTALLING PATCH
 - name: Install VBR patch
@@ -79,7 +81,9 @@
   ansible.windows.win_shell: |
     if (-Not (Get-Module -ListAvailable -Name Veeam.Backup.PowerShell)){Add-PSSnapin -PassThru VeeamPSSnapIn -ErrorAction Stop | Out-Null}
     Get-VBRJob | Stop-VBRJob | Out-Null
-    Get-Service veeam* | Stop-Service
+    $service = Get-Service veeam* | Where-Object {"Running" -eq $_.Status}
+    if ($service) {$service | Stop-Service -Force -ErrorAction SilentlyContinue}
+  retries: 3
   when: not (patch | bool)
 - name: Rebooting server now to complete VBR patch installation
   ansible.windows.win_reboot:

--- a/roles/veeam_vas/tasks/vbr_upgrade.yml
+++ b/roles/veeam_vas/tasks/vbr_upgrade.yml
@@ -39,11 +39,13 @@
   community.windows.win_file_version:
     path: "{{ file.files[0].path }}"
   register: file_version
-  when: file.matched | bool
+  when: file.matched > 0
 - name: Legacy install process will be used
   ansible.builtin.set_fact:
     legacy: true
-  when: not file.matched | bool or file_version.win_file_version.file_version == '1.0.0.0'
+  when:
+    - file.matched == 0
+    - file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Upgrade Configuration
 - name: Print Upgrade Configuration

--- a/roles/veeam_vas/templates/EM/EmAnswerFile_install.xml.j2
+++ b/roles/veeam_vas/templates/EM/EmAnswerFile_install.xml.j2
@@ -175,12 +175,6 @@
 		<!--Setup settings-->
 		<!--Specify additional setup settings-->
 
-			<!--[Optional] Parameter VBCP_INSTALL specifies if Veeam Cloud Connect Portal will be installed. If you do not specify this parameter, it will not be installed-->
-				<!--Supported values: 0/1-->
-				{% if cloud_connect %}
-				<property name="VBCP_INSTALL" value="1" />
-				{% endif %}
-
 			<!--[Optional] Parameter VBREM_CONFIG_SCHANNEL specifies if the TLS 1.2 protocol will be used for secure communication with the Veeam Backup Enterprise Manager website-->
 				<!--Supported values: 0/1-->
 				<property name="VBREM_CONFIG_SCHANNEL" value="{{ em_tls }}" />

--- a/roles/veeam_vas/templates/EM/EmAnswerFile_upgrade.xml.j2
+++ b/roles/veeam_vas/templates/EM/EmAnswerFile_upgrade.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattendedInstallationConfiguration bundle="Em" mode="upgrade" version="1.0">
-<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->    
+<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->
 <!--Supported values: install/upgrade/uninstall-->
 
 <!--Note: unused [Optional] parameters should be removed from the answer file-->
@@ -30,12 +30,18 @@
 		<!--Specify path to a license file and autoupdate option-->
 
 			<!--[Required] Parameter VBREM_LICENSE_FILE specifies a full path to the license file. If you do not specify this parameter, Veeam Backup & Replication will be installed in the Community Edition mode or upgraded using current license file-->
-				<!--Supported values: file path-->    
+				<!--Supported values: file path-->
 				<property name="VBREM_LICENSE_FILE" value="{{ destination }}{{ destination_license_file }}" />
 
 			<!--[Optional] Parameter VBREM_LICENSE_AUTOUPDATE specifies if you want to update license automatically. If you do not specify this parameter, autoupdate will be enabled. For NFR and Evaluation licenses it must be set to 1. For licenses without license ID information it must be set to 0-->
 				<!--Supported values: 0/1-->
 				<property name="VBREM_LICENSE_AUTOUPDATE" value="{{ license_autoupdate }}" />
+
+			{% if version | int >= 13 %}
+			<!--  [Optional] Parameter VBREM_PROACTIVE_SUPPORT specifies if you want to receive proactive support (enables diagnostic data sharing). If you do not specify this parameter, proactive support will be enabled. For Community Edition, NFR and Evaluation licenses it must be set to 1. For licenses without license ID information it must be set to 0 -->
+				<!--  Supported values: 0/1  -->
+				<property name="VBREM_PROACTIVE_SUPPORT" value="{{ proactive_support }}"/>
+			{% endif %}
 
 		<!--Service account-->
 
@@ -44,16 +50,6 @@
 				<!--Supported values: password in plain text-->
 				{% if service_account_username != 'LocalSystem' %}
 				<property name="VBREM_SERVICE_PASSWORD" value="{{ service_account_password }}" hidden="1"/>
-				{% endif %}
-
-		<!--Database configuration-->
-		<!--Specify database server installation options and required configuration parameters for Veeam Backup Enterprise Manager database-->
-
-			<!--[Optional] Parameter VBREM_SQLSERVER_PASSWORD specifies a password to connect to the SQL server in the native authentication mode. Required when VBREM_SQLSERVER_USERNAME is used-->
-			<!--Make sure you keep the answer file in a safe location whenever SQL server account password is added to the answer file-->
-				<!--Supported values: password in plain text-->
-				{% if sql_authentication == '1' %}
-				<property name="VBREM_SQLSERVER_PASSWORD" value="{{ sql_password }}" hidden="1"/>
 				{% endif %}
 
 		<!--Setup settings-->

--- a/roles/veeam_vas/templates/VBR/VbrAnswerFile_install.xml.j2
+++ b/roles/veeam_vas/templates/VBR/VbrAnswerFile_install.xml.j2
@@ -71,11 +71,7 @@
 				<!-- Specify Microsoft Entra ID database server installation options. -->
 				<!-- [Optional] Parameter VBR_ENTRAID_DATABASE_INSTALL specifies if bundled PostgreSQL server for Microsoft EntraID will be installed. If set to '0', PostgreSQL Database won't be installed -->
 				<!-- Supported values: 0/1 -->
-				{% if vbr_entra_id_install %}
-				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="1"/>
-				{% else %}
-				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="0"/>
-				{% endif %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="{{ vbr_entra_id_install }}"/>
 
 			<!--[Optional] Parameter VBR_SQLSERVER_ENGINE specifies SQL server type: '1' for PostgreSQL server, '0' for Microsoft SQL server.  Required when VBR_SQLSERVER_INSTALL is set to '0'-->
 				<!--Supported values: 0/1-->

--- a/roles/veeam_vas/templates/VBR/VbrAnswerFile_install.xml.j2
+++ b/roles/veeam_vas/templates/VBR/VbrAnswerFile_install.xml.j2
@@ -67,6 +67,16 @@
 				<property name="VBR_SQLSERVER_INSTALL" value="0" />
 				{% endif %}
 
+				<!-- Microsoft Entra ID Database configuration -->
+				<!-- Specify Microsoft Entra ID database server installation options. -->
+				<!-- [Optional] Parameter VBR_ENTRAID_DATABASE_INSTALL specifies if bundled PostgreSQL server for Microsoft EntraID will be installed. If set to '0', PostgreSQL Database won't be installed -->
+				<!-- Supported values: 0/1 -->
+				{% if vbr_entra_id_install %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="1"/>
+				{% else %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="0"/>
+				{% endif %}
+
 			<!--[Optional] Parameter VBR_SQLSERVER_ENGINE specifies SQL server type: '1' for PostgreSQL server, '0' for Microsoft SQL server.  Required when VBR_SQLSERVER_INSTALL is set to '0'-->
 				<!--Supported values: 0/1-->
 				<property name="VBR_SQLSERVER_ENGINE" value="{{ sql_engine }}" />
@@ -163,8 +173,17 @@
 				<property name="AHV_INSTALL" value="{{ vbr_ahv_install }}" />
 
 			<!--[Optional] Parameter RHV_INSTALL specifies if Red Hat Virtualization Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
+			<!--WILL BE REMOVED ONCE THIS COLLECTION STOPS SUPPORTING <12.1-->
 				<!--Supported values: 0/1-->
 				<property name="RHV_INSTALL" value="{{ vbr_rhv_install }}" />
+
+			<!--[Optional] Parameter KVM_INSTALL specifies if oVirt KVM Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
+				<!--Supported values: 0/1-->
+				<property name="KVM_INSTALL" value="{{ vbr_kvm_install }}" />
+
+			<!--[Optional] Parameter PVE_INSTALL specifies if Proxmox Virtual Environment Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
+				<!--Supported values: 0/1-->
+				<property name="PVE_INSTALL" value="{{ vbr_pve_install }}" />
 
 			<!--[Optional] Parameter AWS_INSTALL specifies if AWS Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will be installed-->
 				<!--Supported values: 0/1-->

--- a/roles/veeam_vas/templates/VBR/VbrAnswerFile_upgrade.xml.j2
+++ b/roles/veeam_vas/templates/VBR/VbrAnswerFile_upgrade.xml.j2
@@ -41,6 +41,12 @@
 				<property name="VBR_LICENSE_AUTOUPDATE" value="{{ license_autoupdate }}" />
 				{% endif %}
 
+			{% if version | int >= 13 %}
+			<!--  [Optional] Parameter VBR_PROACTIVE_SUPPORT specifies if you want to receive proactive support (enables diagnostic data sharing). If you do not specify this parameter, proactive support will be enabled. For Community Edition, NFR and Evaluation licenses it must be set to 1. For licenses without license ID information it must be set to 0 -->
+				<!--  Supported values: 0/1  -->
+				<property name="VBR_PROACTIVE_SUPPORT" value="{{ proactive_support }}"/>
+			{% endif %}
+
 		<!--Service account-->
 
 			<!--[Optional] Parameter VBR_SERVICE_PASSWORD specifies a password for the account under which the Veeam Backup Service is running. Required during upgrade if service account is not LocalSystem account-->
@@ -53,22 +59,11 @@
 		<!--Database configuration-->
 		<!--Specify database server installation options and required configuration parameters for Veeam Backup & Replication database-->
 
-			<!--[Optional] Parameter VBR_SQLSERVER_PASSWORD specifies a password to connect to the SQL server in the native authentication mode-->
-			<!--Make sure you keep the answer file in a safe location whenever SQL server account password is added to the answer file-->
-				<!--Supported values: password in plain text-->
-				{% if sql_authentication == '1' %}
-				<property name="VBR_SQLSERVER_PASSWORD" value="{{ sql_password }}" hidden="1"/>
-				{% endif %}
-
 			<!-- Microsoft Entra ID Database configuration -->
 			<!-- Specify Microsoft Entra ID database server installation options. -->
 			<!-- [Optional] Parameter VBR_ENTRAID_DATABASE_INSTALL specifies if bundled PostgreSQL server for Microsoft EntraID will be installed. If set to '0', PostgreSQL Database won't be installed -->
 				<!-- Supported values: 0/1 -->
-				{% if vbr_entra_id_install %}
-				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="1"/>
-				{% else %}
-				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="0"/>
-				{% endif %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="{{ vbr_entra_id_install }}"/>
 
 		<!--Automatic update settings-->
 		<!--Specify Veeam B&R autoupdate settings-->

--- a/roles/veeam_vas/templates/VBR/VbrAnswerFile_upgrade.xml.j2
+++ b/roles/veeam_vas/templates/VBR/VbrAnswerFile_upgrade.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattendedInstallationConfiguration bundle="Vbr" mode="upgrade" version="1.0">
-<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->    
+<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->
 <!--Supported values: install/upgrade/uninstall-->
 
 <!--Note: unused [Optional] parameters should be removed from the answer file-->
@@ -30,7 +30,7 @@
 		<!--Specify path to a license file and autoupdate option-->
 
 			<!--[Optional] Parameter VBR_LICENSE_FILE specifies a full path to the license file. If you do not specify this parameter(or leave it empty value), Veeam Backup & Replication will be installed using current license file. To install Community Edition it must be set to 0-->
-				<!--Supported values: file path/0(to install CE)-->    
+				<!--Supported values: file path/0(to install CE)-->
 				{% if license %}
 				<property name="VBR_LICENSE_FILE" value="{{ destination }}{{ destination_license_file }}" />
 				{% endif %}
@@ -58,6 +58,16 @@
 				<!--Supported values: password in plain text-->
 				{% if sql_authentication == '1' %}
 				<property name="VBR_SQLSERVER_PASSWORD" value="{{ sql_password }}" hidden="1"/>
+				{% endif %}
+
+			<!-- Microsoft Entra ID Database configuration -->
+			<!-- Specify Microsoft Entra ID database server installation options. -->
+			<!-- [Optional] Parameter VBR_ENTRAID_DATABASE_INSTALL specifies if bundled PostgreSQL server for Microsoft EntraID will be installed. If set to '0', PostgreSQL Database won't be installed -->
+				<!-- Supported values: 0/1 -->
+				{% if vbr_entra_id_install %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="1"/>
+				{% else %}
+				<property name="VBR_ENTRAID_DATABASE_INSTALL" value="0"/>
 				{% endif %}
 
 		<!--Automatic update settings-->

--- a/roles/veeam_vas/templates/VBRConsole/VbrConsoleAnswerFile_install.xml.j2
+++ b/roles/veeam_vas/templates/VBRConsole/VbrConsoleAnswerFile_install.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattendedInstallationConfiguration bundle="VbrConsole" mode="install" version="1.0">
-<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->    
+<!--[Required] Parameter 'mode' defines installation mode that silent install should operate in-->
 <!--Supported values: install/upgrade/uninstall-->
 
 <!--Note: unused [Optional] parameters should be removed from the answer file-->
@@ -39,12 +39,20 @@
 		<!--Specify additional components to install-->
 
 			<!--[Optional] Parameter AHV_INSTALL specifies if Nutanix AHV Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
-				<!--Supported values: 0/1-->            
+				<!--Supported values: 0/1-->
 				<property name="AHV_INSTALL" value="{{ vbr_ahv_install }}" />
 
 			<!--[Optional] Parameter RHV_INSTALL specifies if Red Hat Virtualization Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
 				<!--Supported values: 0/1-->
 				<property name="RHV_INSTALL" value="{{ vbr_rhv_install }}" />
+
+			<!--[Optional] Parameter KVM_INSTALL specifies if oVirt KVM Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
+				<!--Supported values: 0/1-->
+				<property name="KVM_INSTALL" value="{{ vbr_kvm_install }}" />
+
+			<!--[Optional] Parameter PVE_INSTALL specifies if Proxmox Virtual Environment Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will not be installed-->
+			<!--Supported values: 0/1-->
+				<property name="PVE_INSTALL" value="{{ vbr_pve_install }}" />
 
 			<!--[Optional] Parameter AWS_INSTALL specifies if AWS Plug-in for Veeam Backup & Replication will be installed. If you do not specify this parameter, plug-in will be installed-->
 				<!--Supported values: 0/1-->

--- a/roles/veeam_vas/vars/em_v12.yml
+++ b/roles/veeam_vas/vars/em_v12.yml
@@ -1,8 +1,8 @@
 ---
 # EM v12 vars file for veeamhub.veeam_vas
 
-iso_url: "https://download2.veeam.com/VBR/v12/VeeamBackup&Replication_12.1.2.172_20240515.iso"
-iso_checksum: "3e9e11cb8879ddeb4558ca8de702f7e821a2c25e"
+iso_url: "https://download2.veeam.com/VBR/v12/VeeamBackup&Replication_12.3.2.4165_20251014.iso"
+iso_checksum: "064bf8d47b2307601f21eeb6362eacd08a558c20"
 destination_iso_file: "vbr.iso"
 destination_license_file: "vbr-license.lic"
 sql_instance: "localhost"

--- a/roles/veeam_vas/vars/em_v13.yml
+++ b/roles/veeam_vas/vars/em_v13.yml
@@ -1,0 +1,10 @@
+---
+# EM v12 vars file for veeamhub.veeam_vas
+
+iso_url: "https://download2.veeam.com/VBR/v13/VeeamBackup&Replication_13.0.1.180_20251114.iso"
+iso_checksum: "959d260a5ea1dd990168759014bae18744a53870"
+destination_iso_file: "vbr.iso"
+destination_license_file: "vbr-license.lic"
+sql_instance: "localhost"
+sql_database: "VeeamBackupReporting"
+net_framework_file: "{{ source }}Redistr\\NDP472-KB4054530-x86-x64-AllOS-ENU.exe"

--- a/roles/veeam_vas/vars/vbr_v12.yml
+++ b/roles/veeam_vas/vars/vbr_v12.yml
@@ -1,8 +1,8 @@
 ---
 # VBR v12 vars file for veeamhub.veeam_vas
 
-iso_url: "https://download2.veeam.com/VBR/v12/VeeamBackup&Replication_12.1.2.172_20240515.iso"
-iso_checksum: "3e9e11cb8879ddeb4558ca8de702f7e821a2c25e"
+iso_url: "https://download2.veeam.com/VBR/v12/VeeamBackup&Replication_12.3.2.4165_20251014.iso"
+iso_checksum: "064bf8d47b2307601f21eeb6362eacd08a558c20"
 destination_iso_file: "vbr.iso"
 destination_license_file: "vbr-license.lic"
 sql_instance: "localhost"

--- a/roles/veeam_vas/vars/vbr_v13.yml
+++ b/roles/veeam_vas/vars/vbr_v13.yml
@@ -1,0 +1,10 @@
+---
+# VBR v13 vars file for veeamhub.veeam_vas
+
+iso_url: "https://download2.veeam.com/VBR/v13/VeeamBackup&Replication_13.0.1.180_20251114.iso"
+iso_checksum: "959d260a5ea1dd990168759014bae18744a53870"
+destination_iso_file: "vbr.iso"
+destination_license_file: "vbr-license.lic"
+sql_instance: "localhost"
+sql_database: "VeeamBackup"
+net_framework_file: "{{ source }}Redistr\\NDP472-KB4054530-x86-x64-AllOS-ENU.exe"


### PR DESCRIPTION
v2.3.4
======

Major Changes
-------------

- Added support for v13

Minor Changes
-------------

- Updated ISO references to latest versions (https://github.com/VeeamHub/veeam-ansible/issues/75)
- Added logic to enable/disable Cloud Connect maintenance mode before/after Veeam Backup & Replication upgrade
- Added support to adjust time to wait for long running tasks to complete (https://github.com/VeeamHub/veeam-ansible/issues/73)

Bugfixes
-------------

- Added logic to disable/enable backup jobs before/after Veeam Backup & Replication upgrade (https://github.com/VeeamHub/veeam-ansible/issues/74)
- Added logic to ensure Veeam services are started before proceeding with upgrade (https://github.com/VeeamHub/veeam-ansible/issues/27)


Breaking Changes
-------------

- Deprecated support for installing Veeam Backup & Replication version 11 and earlier.
- Deprecated support for installing Veeam ONE. Depending on demand, Veeam ONE support may be reintroduced in a future release.

Fixes #27
Fixes #73
Fixes #74
Fixes #75

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

### How Has This Been Tested?

Collection was tested in a lab environment.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
