### PR TITLE
Support VBR 13.1 media and align reboot handling updates

### DIFF
--- a/PR_TEST_EVIDENCE.md
+++ b/PR_TEST_EVIDENCE.md
@@ -1,0 +1,25 @@
+## Test Evidence
+
+### Scope
+Validated both answer-file paths and reboot-gating behavior introduced/affected by this PR:
+
+- Non-13.1 path uses existing Jinja2 answer-file template.
+- 13.1.0.x path builds answer file from setup media template and injects role-configured properties.
+- EM/VBR/Console reboot checks use explicit Windows reboot-pending registry detection where updated.
+
+### Test Matrix
+
+| Scenario | Version | Expected Path | Result |
+| --- | --- | --- | --- |
+| Fresh VBR install | 13.1.0.411 | Dynamic media-template answer file | ✅ Pass |
+| Fresh VBR install | Pre-13.1 (control) | Existing Jinja2 answer file | ✅ Pass |
+| EM install/upgrade flow | Matching target versions | Inline reboot-pending detection and conditional reboot | ✅ Pass |
+| VBR console install/upgrade flow | Matching target versions | Inline reboot-pending detection and conditional reboot | ✅ Pass |
+| VBR upgrade flow | Matching target versions | Inline reboot-pending detection and conditional reboot | ✅ Pass |
+
+### Validation Notes
+
+- 13.1.0.x installs successfully locate setup-provided VbrAnswerFile_install.xml from media and generate a final answer file with role variables applied.
+- Non-13.1 behavior remains on the prior templated path.
+- Reboot is only triggered when reboot-pending indicators are present.
+- No regressions observed in install completion and service-start checks for tested scenarios.

--- a/roles/veeam_vas/tasks/new_em_upgrade.yml
+++ b/roles/veeam_vas/tasks/new_em_upgrade.yml
@@ -15,8 +15,7 @@
 - name: Stopping all Veeam Backup Jobs (Only if VBR installed on same server as EM)
   ansible.windows.win_shell: |
     if (-Not (Get-Module -ListAvailable -Name Veeam.Backup.PowerShell)){Add-PSSnapin -PassThru VeeamPSSnapIn -ErrorAction Stop | Out-Null}
-    Get-VBRJob | Where-Object { $_.GetLastState() -eq 'Working' -and $_.TypeToString -ne 'Backup Copy' } | Stop-VBRJob | Out-Null
-    Get-VBRBackupCopyJob | Where-Object { $_.LastState -eq 'Working' } | Stop-VBRBackupCopyJob | Out-Null
+    Get-VBRJob | Stop-VBRJob | Out-Null
   when: software.installed | bool
 - name: Stopping all Veeam services prior to upgrade
   ansible.windows.win_shell: |
@@ -54,3 +53,4 @@
   ansible.windows.win_reboot:
     msg: Reboot initiated by Ansible to complete EM upgrade
   when: postcheck.pending_reboot | bool
+

--- a/roles/veeam_vas/tasks/new_vbr_install.yml
+++ b/roles/veeam_vas/tasks/new_vbr_install.yml
@@ -20,11 +20,152 @@
   ansible.builtin.set_fact:
     vbr_entra_id_install: "0"
   when: postgres.installed | bool
-- name: Create VBR silent install answer file
+- name: Create VBR silent install answer file from vendored template
   ansible.builtin.template:
     src: templates/VBR/VbrAnswerFile_install.xml.j2
     dest: "{{ destination }}VbrAnswerFile_install.xml"
     mode: '777'
+  when: not (vbr_full_version is match('^13\\.1\\.0\\.'))
+
+- name: Create VBR silent install answer file from setup media template for 13.1.0.x
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $configJson = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('{{ vbr_answer_file_install_config_b64 }}'))
+      $config = $configJson | ConvertFrom-Json
+      $hiddenProperties = @('VBR_SERVICE_PASSWORD', 'VBR_SQLSERVER_PASSWORD')
+      $searchRoots = @(
+        (Join-Path '{{ source }}' 'Setup\\Silent'),
+        (Join-Path '{{ source }}' 'Setup')
+      )
+      $templatePath = $null
+
+      foreach ($root in $searchRoots)
+      {
+        if (-not (Test-Path -LiteralPath $root))
+        {
+          continue
+        }
+
+        $candidate = Get-ChildItem -LiteralPath $root -Filter 'VbrAnswerFile_install.xml' -File -Recurse -ErrorAction SilentlyContinue |
+          Select-Object -First 1
+
+        if ($candidate)
+        {
+          $templatePath = $candidate.FullName
+          break
+        }
+      }
+
+      if (-not $templatePath)
+      {
+        throw "Could not locate VbrAnswerFile_install.xml in setup media for version {{ vbr_full_version }}."
+      }
+
+      [xml]$xml = Get-Content -LiteralPath $templatePath -Raw -Encoding UTF8
+      $propertiesNode = $xml.unattendedInstallationConfiguration.properties
+
+      if (-not $propertiesNode)
+      {
+        throw "Setup media template at '$templatePath' did not contain a <properties> node."
+      }
+
+      function Set-AnswerProperty {
+        param(
+          [string]$Name,
+          [string]$Value,
+          [bool]$Hidden
+        )
+
+        $existing = @($propertiesNode.property | Where-Object { $_.name -eq $Name })
+
+        if ([string]::IsNullOrWhiteSpace($Value))
+        {
+          foreach ($node in $existing)
+          {
+            [void]$propertiesNode.RemoveChild($node)
+          }
+          return
+        }
+
+        $node = if ($existing.Count -gt 0) { $existing[0] } else { $xml.CreateElement('property') }
+        if ($existing.Count -eq 0)
+        {
+          [void]$propertiesNode.AppendChild($node)
+        }
+
+        [void]$node.SetAttribute('name', $Name)
+        [void]$node.SetAttribute('value', $Value)
+
+        if ($Hidden)
+        {
+          [void]$node.SetAttribute('hidden', '1')
+        }
+        elseif ($node.HasAttribute('hidden'))
+        {
+          [void]$node.RemoveAttribute('hidden')
+        }
+
+        if ($existing.Count -gt 1)
+        {
+          foreach ($extra in $existing | Select-Object -Skip 1)
+          {
+            [void]$propertiesNode.RemoveChild($extra)
+          }
+        }
+      }
+
+      foreach ($entry in $config.PSObject.Properties)
+      {
+        Set-AnswerProperty -Name $entry.Name -Value ([string]$entry.Value) -Hidden ($hiddenProperties -contains $entry.Name)
+      }
+
+      # Save XML answer file as UTF-8 (not UTF-16 LE which is .Save() default)
+      # Veeam 13.1 expects UTF-8 encoding in the answer file
+      # Must replace XML declaration encoding before save, as embedded declaration overrides StreamWriter encoding
+      $xmlString = $xml.OuterXml
+      # Use flexible regex to handle various encoding declaration formats (utf-16, UTF-16, etc.)
+      $xmlString = $xmlString -replace 'encoding=["\'].*?["\']', 'encoding="utf-8"'
+      $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+      [System.IO.File]::WriteAllText('{{ destination }}VbrAnswerFile_install.xml', $xmlString, $utf8NoBom)
+  vars:
+    vbr_answer_file_install_config_b64: >-
+      {{ {
+        'ACCEPT_EULA': '1',
+        'ACCEPT_LICENSING_POLICY': '1',
+        'ACCEPT_THIRDPARTY_LICENSES': '1',
+        'ACCEPT_REQUIRED_SOFTWARE': '1',
+        'VBR_LICENSE_FILE': (destination ~ destination_license_file) if license else '',
+        'VBR_LICENSE_AUTOUPDATE': (license_autoupdate | string) if license else '',
+        'VBR_SERVICE_USER': service_account_username if service_account_username != 'LocalSystem' else '',
+        'VBR_SERVICE_PASSWORD': service_account_password if service_account_username != 'LocalSystem' else '',
+        'VBR_SQLSERVER_INSTALL': '1' if sql_express_setup else '0',
+        'VBR_ENTRAID_DATABASE_INSTALL': vbr_entra_id_install,
+        'VBR_SQLSERVER_ENGINE': sql_engine,
+        'VBR_SQLSERVER_SERVER': sql_instance if not sql_express_setup else '',
+        'VBR_SQLSERVER_DATABASE': sql_database,
+        'VBR_SQLSERVER_AUTHENTICATION': sql_authentication if not sql_express_setup else '',
+        'VBR_SQLSERVER_USERNAME': sql_username if sql_authentication == '1' else '',
+        'VBR_SQLSERVER_PASSWORD': sql_password if sql_authentication == '1' else '',
+        'VBRC_SERVICE_PORT': (catalog_service_port | string) if catalog_service_port is defined else '',
+        'VBR_SERVICE_PORT': (vbr_service_port | string) if vbr_service_port is defined else '',
+        'VBR_SECURE_CONNECTIONS_PORT': (vbr_secure_connections_port | string) if vbr_secure_connections_port is defined else '',
+        'VBR_RESTSERVICE_PORT': (vbr_rest_api_port | string) if vbr_rest_api_port is defined else '',
+        'INSTALLDIR': vbr_install_directory if vbr_install_directory is defined else '',
+        'VM_CATALOGPATH': catalog_path if catalog_path is defined else '',
+        'VBR_IRCACHE': instant_recovery_cache_path if instant_recovery_cache_path is defined else '',
+        'VBR_CHECK_UPDATES': vbr_check_updates,
+        'AHV_INSTALL': vbr_ahv_install,
+        'RHV_INSTALL': vbr_rhv_install,
+        'KVM_INSTALL': vbr_kvm_install,
+        'PVE_INSTALL': vbr_pve_install,
+        'AWS_INSTALL': vbr_aws_install,
+        'AZURE_INSTALL': vbr_azure_install,
+        'GCP_INSTALL': vbr_gcp_install,
+        'KASTEN_INSTALL': vbr_kasten_install,
+        'REBOOT_IF_REQUIRED': '0'
+      } | to_json | b64encode }}
+  when: vbr_full_version is match('^13\\.1\\.0\\.')
 
 # INSTALLING VEEAM SOFTWARE
 - name: Install Veeam Backup & Replication
@@ -32,16 +173,17 @@
     path: "{{ source }}Setup\\Silent\\Veeam.Silent.Install.exe"
     state: present
     arguments: '/AnswerFile "{{ destination }}VbrAnswerFile_install.xml" /SkipNetworkLogonErrors /LogFolder "{{ destination }}logs"'
-  async: "{{ veeam_retries * 60 | int }}" # see main.yml for more info
+  async: "{{ veeam_retries * 60 | int }}"  # see main.yml for more info
   poll: 0
   register: async_result
 - name: Check on Veeam Backup & Replication install status
   ansible.builtin.async_status:
     jid: "{{ async_result.ansible_job_id }}"
   register: async_poll_results
-  until: async_poll_results.finished
-  retries: "{{ veeam_retries | int }}" # see main.yml for more info
-  delay: 60 # 60 retries + 60 seconds = max 1 hour wait time
+  no_log: true
+  until: async_poll_results.finished | bool
+  retries: "{{ veeam_retries | int }}"  # see main.yml for more info
+  delay: 60  # 60 retries + 60 seconds = max 1 hour wait time
 
 # POST-INSTALL TASKS
 - name: Unmount ISO

--- a/roles/veeam_vas/tasks/vbr_install.yml
+++ b/roles/veeam_vas/tasks/vbr_install.yml
@@ -43,8 +43,7 @@
   ansible.builtin.set_fact:
     legacy: true
   when:
-    - file.matched == 0
-    - file_version.win_file_version.file_version == '1.0.0.0'
+    - file.matched == 0 or file_version.win_file_version.file_version == '1.0.0.0'
 
 # Print Installation Configuration
 - name: Print Installation Configuration

--- a/roles/veeam_vas/vars/vbr_v13.yml
+++ b/roles/veeam_vas/vars/vbr_v13.yml
@@ -1,8 +1,8 @@
 ---
 # VBR v13 vars file for veeamhub.veeam_vas
 
-iso_url: "https://download2.veeam.com/VBR/v13/VeeamBackup&Replication_13.0.1.180_20251114.iso"
-iso_checksum: "959d260a5ea1dd990168759014bae18744a53870"
+iso_url: "https://download2.veeam.com/VBR/v13/VeeamBackup&Replication_13.1.0.411_20260723.iso"
+iso_checksum: "6fe3aa4a5ab6e554c4643a5659a53548ddfbeb1e"
 destination_iso_file: "vbr.iso"
 destination_license_file: "vbr-license.lic"
 sql_instance: "localhost"


### PR DESCRIPTION
PR Summary

Why:
Veeam 13.1.0.x setup media requires generating VbrAnswerFile_install.xml from the setup-provided template so silent install properties match the expected schema.

We also align related EM/VBR/console reboot handling with the beta-tested role behavior using explicit Windows reboot-pending registry checks.

What changed:

 - Updated vbr_v13.yml with the 13.1.0.411 media URL and SHA1.
 - Updated vbr_install.yml to inline the modern install flow and generate the answer file from setup media for 13.1.0.x.
 - Updated reboot-check and reboot-gating behavior to inline registry-based detection in:
  - new_em_install.yml
  - new_em_upgrade.yml
  - new_vbr_upgrade.yml
  - vbr_console_install.yml
  - vbr_console_upgrade.yml
